### PR TITLE
Add compatibility to work with py2neo version 3.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
+
+    install_requires=['tqdm']
 )


### PR DESCRIPTION
Hi Daniel,

I've finished making my changes to the `hetio` package to make it compatible with py2neo version 3.1.2. I didn't actually have to end up changing too much in the package. The only real difference between py2neo versions is that when nodes and edges are added to neo4j, they are done as a single subgraph object, and not as multiple objects.

I also added a progress bar to the neo4j export process, which allows me to watch how things are going from the command line. This option is off by default in order to ensure it does not break your previous work. In that regard I have also tested things with your original code, and things worked fine.

I have only modified the `neo4j.py` file, and found that no other changes in `hetio` were needed to make the rest of the pipeline work. All other changes were done in the respective `integrate` and `learn` repositories.

One thing you might notice is that the `uri` variable passed to `export_neo4j()` is actually expected to be a `py2neo.Graph` object, but only if using py2neo version 3. In my testing it seemed that I could not get the py2neo URI resolver to work with the new Bolt protocol. Instead I had to open my own py2neo connection explicitly, and that seems to work. I believe the problem is that both the Bolt and HTTP ports have to be open, and on different ports, and the URI resolver might not support doing that.

Let me know if you have any questions!

Toby