### PR TITLE
Migrate hetnet to matrix code from greenelab/hetmech

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ addons:
   apt_packages:
     - pandoc
 install:
-  - python setup.py install
+  - pip install .[test]
   - python setup.py sdist bdist_wheel
-script: py.test
+script:
+  - py.test
 deploy:
   - provider: releases
     api_key:

--- a/hetio/matrix.py
+++ b/hetio/matrix.py
@@ -1,0 +1,125 @@
+from collections import OrderedDict
+
+import hetio.hetnet
+import numpy
+from scipy import sparse
+
+
+def get_node_to_position(graph, metanode):
+    """
+    Given a metanode, return a dictionary of node to position
+    """
+    if not isinstance(metanode, hetio.hetnet.MetaNode):
+        # metanode is a name
+        metanode = graph.metagraph.node_dict[metanode]
+    metanode_to_nodes = graph.get_metanode_to_nodes()
+    nodes = sorted(metanode_to_nodes[metanode])
+    node_to_position = OrderedDict((n, i) for i, n in enumerate(nodes))
+    return node_to_position
+
+
+def metaedge_to_adjacency_matrix(graph, metaedge, dtype=numpy.bool_,
+                                 sparse_threshold=0):
+    """
+    Returns an adjacency matrix where source nodes are rows and target
+    nodes are columns.
+
+    Parameters
+    ==========
+    graph : hetio.hetnet.graph
+    metaedge : hetio.hetnet.MetaEdge
+    dtype : type
+    sparse_threshold : float (0 < sparse_threshold < 1)
+        sets the density threshold above which a sparse matrix will be
+        converted to a dense automatically.
+    """
+    if not isinstance(metaedge, hetio.hetnet.MetaEdge):
+        # metaedge is an abbreviation
+        metaedge = graph.metagraph.metapath_from_abbrev(metaedge)[0]
+    source_nodes = list(get_node_to_position(graph, metaedge.source))
+    target_node_to_position = get_node_to_position(graph, metaedge.target)
+    shape = len(source_nodes), len(target_node_to_position)
+    row, col, data = [], [], []
+    for i, source_node in enumerate(source_nodes):
+        for edge in source_node.edges[metaedge]:
+            row.append(i)
+            col.append(target_node_to_position[edge.target])
+            data.append(1)
+    adjacency_matrix = sparse.csc_matrix((data, (row, col)), shape=shape,
+                                         dtype=dtype)
+    adjacency_matrix = auto_convert(adjacency_matrix, sparse_threshold)
+    row_names = [node.identifier for node in source_nodes]
+    column_names = [node.identifier for node in target_node_to_position]
+    return row_names, column_names, adjacency_matrix
+
+
+def normalize(matrix, vector, axis, damping_exponent):
+    """
+    Normalize a 2D numpy.ndarray.
+
+    Parameters
+    ==========
+    matrix : numpy.ndarray or scipy.sparse
+    vector : numpy.ndarray
+        Vector used for row or column normalization of matrix.
+    axis : str
+        'rows' or 'columns' for which axis to normalize
+    damping_exponent : float
+        exponent to use in scaling a node's row or column
+    """
+    assert matrix.ndim == 2
+    assert vector.ndim == 1
+    if damping_exponent == 0:
+        return matrix
+    with numpy.errstate(divide='ignore'):
+        vector **= -damping_exponent
+    vector[numpy.isinf(vector)] = 0
+    vector = sparse.diags(vector)
+    if axis == 'rows':
+        # equivalent to `vector @ matrix` but returns sparse.csc not sparse.csr
+        matrix = (matrix.transpose() @ vector).transpose()
+    else:
+        matrix = matrix @ vector
+    return matrix
+
+
+def auto_convert(matrix, threshold):
+    """
+    Automatically convert a scipy.sparse to a numpy.ndarray if the percent
+    nonzero is above a given threshold. Automatically convert a numpy.ndarray
+    to scipy.sparse if the percent nonzero is below a given threshold.
+
+    Parameters
+    ==========
+    matrix : numpy.ndarray or scipy.sparse
+    threshold : float (0 < threshold < 1)
+        percent nonzero above which the matrix is converted to dense
+
+    Returns
+    =======
+    matrix : numpy.ndarray or scipy.sparse
+    """
+    above_thresh = (matrix != 0).sum() / numpy.prod(matrix.shape) >= threshold
+    if sparse.issparse(matrix) and above_thresh:
+        return matrix.toarray()
+    elif not above_thresh:
+        return sparse.csc_matrix(matrix)
+    return matrix
+
+
+def copy_array(matrix, copy=True):
+    """Returns a newly allocated array if copy is True"""
+    assert matrix.ndim == 2
+    assert matrix.dtype != 'O'  # Ensures no empty row
+    if not sparse.issparse(matrix):
+        assert numpy.isfinite(matrix).all()  # Checks NaN and Inf
+    try:
+        matrix[0, 0]  # Checks that there is a value in the matrix
+    except IndexError:
+        raise AssertionError("Array may have empty rows")
+
+    mat_type = type(matrix)
+    if mat_type == numpy.ndarray:
+        mat_type = numpy.array
+    matrix = mat_type(matrix, dtype=numpy.float64, copy=copy)
+    return matrix

--- a/hetio/matrix.py
+++ b/hetio/matrix.py
@@ -54,13 +54,13 @@ def metaedge_to_adjacency_matrix(
             data.append(1)
     adjacency_matrix = scipy.sparse.csc_matrix(
         (data, (row, col)), shape=shape, dtype=dtype)
-    adjacency_matrix = auto_convert(adjacency_matrix, dense_threshold)
+    adjacency_matrix = sparsify_or_densify(adjacency_matrix, dense_threshold)
     row_names = [node.identifier for node in source_nodes]
     column_names = [node.identifier for node in target_node_to_position]
     return row_names, column_names, adjacency_matrix
 
 
-def auto_convert(matrix, dense_threshold=0.3):
+def sparsify_or_densify(matrix, dense_threshold=0.3):
     """
     Automatically convert a scipy.sparse to a numpy.ndarray if the percent
     nonzero is above a given threshold. Automatically convert a numpy.ndarray

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ except Exception as error:
     with open(readme_path) as read_file:
         long_description = read_file.read()
 
+# Testing dependencies
+tests_require = [
+    'numpy',
+    'scipy',
+]
 
 setuptools.setup(
     # Package details
@@ -66,9 +71,14 @@ setuptools.setup(
         'regex',
     ],
 
+    # Testing dependencies
+    tests_require=tests_require,
+
     # Additional groups of dependencies
     extras_require={
         'stats': ['pandas', 'matplotlib', 'seaborn'],
         'neo4j': ['pandas', 'py2neo', 'tqdm'],
+        'matrix': ['numpy', 'scipy'],
+        'test': tests_require,
     }
 )

--- a/test/matrtix_test.py
+++ b/test/matrtix_test.py
@@ -1,9 +1,13 @@
-import hetio.readwrite
+import os
+
 import numpy
 import pytest
-from scipy import sparse
+import scipy.sparse
 
-from .matrix import metaedge_to_adjacency_matrix
+from hetio.matrix import metaedge_to_adjacency_matrix
+import hetio.readwrite
+
+directory = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_arrays(edge, dtype, threshold):
@@ -37,31 +41,28 @@ def get_arrays(edge, dtype, threshold):
     col_names = node_dict[edge[-1]]
 
     if adj_dict[edge][1] < threshold:
-        adj_matrix = sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
+        adj_matrix = scipy.sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
     else:
         adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
 
     return row_names, col_names, adj_matrix
 
 
-@pytest.mark.parametrize('threshold', [0, 0.25, 0.5, 1])
+@pytest.mark.parametrize('dense_threshold', [0, 0.25, 0.5, 1])
 @pytest.mark.parametrize("dtype", [numpy.bool_, numpy.int64, numpy.float64])
 @pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
-def test_metaedge_to_adjacency_matrix(test_edge, dtype, threshold):
+def test_metaedge_to_adjacency_matrix(test_edge, dtype, dense_threshold):
     """
     Test the functionality of metaedge_to_adjacency_matrix in generating
     numpy arrays. Uses same test data as in test_degree_weight.py
     Figure 2D of Himmelstein & Baranzini (2015) PLOS Comp Bio.
     https://doi.org/10.1371/journal.pcbi.1004259.g002
     """
-    url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
-        '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
-        'test/data/disease-gene-example-graph.json',
-    )
-    graph = hetio.readwrite.read_graph(url)
+    path = os.path.join(directory, 'data', 'disease-gene-example-graph.json')
+    graph = hetio.readwrite.read_graph(path)
     row_names, col_names, adj_mat = metaedge_to_adjacency_matrix(
-        graph, test_edge, dtype=dtype, sparse_threshold=threshold)
-    exp_row, exp_col, exp_adj = get_arrays(test_edge, dtype, threshold)
+        graph, test_edge, dtype=dtype, dense_threshold=dense_threshold)
+    exp_row, exp_col, exp_adj = get_arrays(test_edge, dtype, dense_threshold)
 
     assert row_names == exp_row
     assert col_names == exp_col

--- a/test/matrtix_test.py
+++ b/test/matrtix_test.py
@@ -1,0 +1,71 @@
+import hetio.readwrite
+import numpy
+import pytest
+from scipy import sparse
+
+from .matrix import metaedge_to_adjacency_matrix
+
+
+def get_arrays(edge, dtype, threshold):
+    # Dictionary with tuples of matrix and percent nonzero
+    adj_dict = {
+        'GiG': ([[0, 0, 1, 0, 1, 0, 0],
+                 [0, 0, 1, 0, 0, 0, 0],
+                 [1, 1, 0, 1, 0, 0, 1],
+                 [0, 0, 1, 0, 0, 0, 0],
+                 [1, 0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0, 0],
+                 [0, 0, 1, 0, 0, 0, 0]], 0.204),
+        'GaD': ([[0, 1],
+                 [0, 1],
+                 [1, 0],
+                 [0, 1],
+                 [0, 0],
+                 [1, 1],
+                 [0, 0]], 0.429),
+        'DlT': ([[0, 0],
+                 [1, 0]], 0.25),
+        'TlD': ([[0, 1],
+                 [0, 0]], 0.25)
+    }
+    node_dict = {
+        'G': ['CXCR4', 'IL2RA', 'IRF1', 'IRF8', 'ITCH', 'STAT3', 'SUMO1'],
+        'D': ["Crohn's Disease", 'Multiple Sclerosis'],
+        'T': ['Leukocyte', 'Lung']
+    }
+    row_names = node_dict[edge[0]]
+    col_names = node_dict[edge[-1]]
+
+    if adj_dict[edge][1] < threshold:
+        adj_matrix = sparse.csc_matrix(adj_dict[edge][0], dtype=dtype)
+    else:
+        adj_matrix = numpy.array(adj_dict[edge][0], dtype=dtype)
+
+    return row_names, col_names, adj_matrix
+
+
+@pytest.mark.parametrize('threshold', [0, 0.25, 0.5, 1])
+@pytest.mark.parametrize("dtype", [numpy.bool_, numpy.int64, numpy.float64])
+@pytest.mark.parametrize("test_edge", ['GiG', 'GaD', 'DlT', 'TlD'])
+def test_metaedge_to_adjacency_matrix(test_edge, dtype, threshold):
+    """
+    Test the functionality of metaedge_to_adjacency_matrix in generating
+    numpy arrays. Uses same test data as in test_degree_weight.py
+    Figure 2D of Himmelstein & Baranzini (2015) PLOS Comp Bio.
+    https://doi.org/10.1371/journal.pcbi.1004259.g002
+    """
+    url = 'https://github.com/dhimmel/hetio/raw/{}/{}'.format(
+        '9dc747b8fc4e23ef3437829ffde4d047f2e1bdde',
+        'test/data/disease-gene-example-graph.json',
+    )
+    graph = hetio.readwrite.read_graph(url)
+    row_names, col_names, adj_mat = metaedge_to_adjacency_matrix(
+        graph, test_edge, dtype=dtype, sparse_threshold=threshold)
+    exp_row, exp_col, exp_adj = get_arrays(test_edge, dtype, threshold)
+
+    assert row_names == exp_row
+    assert col_names == exp_col
+    assert type(adj_mat) == type(exp_adj)
+    assert adj_mat.dtype == dtype
+    assert adj_mat.shape == exp_adj.shape
+    assert (adj_mat != exp_adj).sum() == 0


### PR DESCRIPTION
@zietzm I set you as the author for the commit with the unmodified hetmech code, since you wrote most of that. Can you review the changes in https://github.com/dhimmel/hetio/commit/1cbfa8455c6775947a58b48807d0cdfe13866d1c.

The motivation for moving this to `hetio` is that it will be useful to many users. By moving it here, we're committing to a higher degree of API stability and code maturity.