### PR TITLE
Add warning for the scipy bug if numpy.float16 is passed.

### DIFF
--- a/hetio/matrix.py
+++ b/hetio/matrix.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
-from logging import warning
 
+import logging
 import numpy
 import scipy.sparse
 
@@ -83,13 +83,15 @@ def sparsify_or_densify(matrix, dense_threshold=0.3):
     density = (matrix != 0).sum() / numpy.prod(matrix.shape)
     densify = density >= dense_threshold
     sparse_input = scipy.sparse.issparse(matrix)
+    dtype = matrix.dtype
     if sparse_input and densify:
         try:
             return matrix.toarray()
         except ValueError:
-            warning(("scipy.sparse does not support the conversion "
-                     "of numpy.float16 matrices to numpy.arrays."))
-            return matrix.astype(numpy.float32).toarray().astype(numpy.float16)
+            logging.warning("scipy.sparse does not support the conversion "
+                            "of numpy.float16 matrices to numpy.arrays. See "
+                            "https://git.io/vpXyy")
+            return matrix.astype(numpy.float32).toarray().astype(dtype)
     if not sparse_input and not densify:
-        return scipy.sparse.csc_matrix(matrix)
+        return scipy.sparse.csc_matrix(matrix, dtype=dtype)
     return matrix

--- a/hetio/matrix.py
+++ b/hetio/matrix.py
@@ -1,9 +1,9 @@
 from collections import OrderedDict
-
-import numpy
-import scipy.sparse
+from logging import warning
 
 import hetio.hetnet
+import numpy
+import scipy.sparse
 
 
 def get_node_to_position(graph, metanode):
@@ -83,7 +83,13 @@ def sparsify_or_densify(matrix, dense_threshold=0.3):
     densify = density >= dense_threshold
     sparse_input = scipy.sparse.issparse(matrix)
     if sparse_input and densify:
-        return matrix.toarray()
+        try:
+            return matrix.toarray()
+        except ValueError:
+            warning(("scipy.sparse does not support the conversion "
+                     "of numpy.float16 matrices to numpy.arrays. Converting "
+                     "to numpy.float32 dtype"))
+            return matrix.astype(numpy.float32).toarray()
     if not sparse_input and not densify:
         return scipy.sparse.csc_matrix(matrix)
     return matrix

--- a/hetio/matrix.py
+++ b/hetio/matrix.py
@@ -1,9 +1,10 @@
 from collections import OrderedDict
 from logging import warning
 
-import hetio.hetnet
 import numpy
 import scipy.sparse
+
+import hetio.hetnet
 
 
 def get_node_to_position(graph, metanode):
@@ -87,9 +88,8 @@ def sparsify_or_densify(matrix, dense_threshold=0.3):
             return matrix.toarray()
         except ValueError:
             warning(("scipy.sparse does not support the conversion "
-                     "of numpy.float16 matrices to numpy.arrays. Converting "
-                     "to numpy.float32 dtype"))
-            return matrix.astype(numpy.float32).toarray()
+                     "of numpy.float16 matrices to numpy.arrays."))
+            return matrix.astype(numpy.float32).toarray().astype(numpy.float16)
     if not sparse_input and not densify:
         return scipy.sparse.csc_matrix(matrix)
     return matrix


### PR DESCRIPTION
In reference to https://github.com/greenelab/hetmech/pull/94 and https://github.com/scipy/scipy/issues/7408. Rather than raising a `ValueError` in a case like:

```python
metaedge_to_adjacency_matrix(graph, 'TeGaDaG', dtype=numpy.float16, dense_threshold=0)
```
it autoconverts to `numpy.float32` and issues a warning.
